### PR TITLE
Feat/workspace join requests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.experimental.useTsgo": false
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@scalar/hono-api-reference": "^0.5.166",
     "@t3-oss/env-nextjs": "^0.10.1",
     "@tanstack/react-query": "^5.62.11",
+    "@tanstack/react-table": "^8.21.3",
     "arctic": "^3.2.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.62.11
         version: 5.62.11(react@18.3.1)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       arctic:
         specifier: ^3.2.3
         version: 3.2.3
@@ -2874,6 +2877,17 @@ packages:
     resolution: {integrity: sha512-Xb1nw0cYMdtFmwkvH9+y5yYFhXvLRCnXoqlzSw7UkqtCVFq3cG8q+rHZ2Yz1XrC+/ysUaTqbLKJqk95mCgC1oQ==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -9985,6 +9999,14 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.62.9
       react: 18.3.1
+
+  '@tanstack/react-table@8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@testing-library/dom@10.4.0':
     dependencies:

--- a/src/app/(dashboard)/dashboard/workspaces/[workspaceId]/invites/page.tsx
+++ b/src/app/(dashboard)/dashboard/workspaces/[workspaceId]/invites/page.tsx
@@ -2,12 +2,10 @@
 import { useWorkspace } from "@/features/workspaces/api/use-workspace";
 import { PageLoader } from "@/components/shared/page-loader";
 import { InviteCard } from "@/features/workspaces/components/invite-card";
-import { useWorkspaceInvites } from "@/features/workspaces/api/use-workspace-invites";
+import { InvitesTable } from "@/features/workspaces/components/invites-table";
 
 function Page({ params }: { params: { workspaceId: string } }) {
   const { data, isLoading, isError, error } = useWorkspace(params.workspaceId);
-  const { data: invitesData } = useWorkspaceInvites(params.workspaceId);
-  console.log(invitesData);
 
   if (isLoading) return <PageLoader />;
 
@@ -21,19 +19,19 @@ function Page({ params }: { params: { workspaceId: string } }) {
     );
   }
 
+  console.log(data?.role);
+
   return (
     <div className="mx-auto w-full lg:max-w-xl">
-      {data && <InviteCard workspace={data} />}
-      {invitesData && (
-        <>
-          {invitesData.pages.map((page) =>
-            page.invites.map((invite) => (
-              <p key={invite.id}>
-                {invite.name} {invite.createdAt}
-              </p>
-            )),
-          )}
-        </>
+      {data && (
+        <div className="flex flex-col gap-8">
+          <InviteCard workspace={data} />
+          <InvitesTable
+            workspaceId={data.id}
+            role={data.role}
+            allowMemberInviteManagement={data.allowMemberInviteManagement}
+          />
+        </div>
       )}
     </div>
   );

--- a/src/components/shared/pagination/index.ts
+++ b/src/components/shared/pagination/index.ts
@@ -1,0 +1,1 @@
+export * from "./pagination";

--- a/src/components/shared/pagination/pagination.tsx
+++ b/src/components/shared/pagination/pagination.tsx
@@ -1,0 +1,111 @@
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+} from "lucide-react";
+
+import type { UsePaginationSearchParamsReturnT } from "@/hooks/use-pagination-search-params";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+export type PaginationProps = {
+  totalPages: number;
+  currentPage: number;
+  className?: string;
+  canGetPrevPage: boolean;
+  canGetNextPage: boolean;
+} & Omit<UsePaginationSearchParamsReturnT, "page">;
+
+export function Pagination({
+  totalPages,
+  currentPage,
+  first,
+  prev,
+  next,
+  last,
+  setPage,
+  className,
+  canGetPrevPage,
+  canGetNextPage,
+}: PaginationProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center gap-2 px-4 pb-6",
+        className,
+      )}
+    >
+      <Button
+        variant="outline"
+        className="h-8 w-8 p-0 lg:flex"
+        onClick={() => first()}
+        disabled={canGetPrevPage}
+      >
+        <span className="sr-only">Go to first page</span>
+        <ChevronsLeft />
+      </Button>
+
+      <Button
+        variant="outline"
+        className="size-8"
+        size="icon"
+        onClick={() => prev(totalPages)}
+        disabled={canGetPrevPage}
+      >
+        <span className="sr-only">Go to previous page</span>
+        <ChevronLeft />
+      </Button>
+
+      {totalPages > 1 ? (
+        <Select
+          value={currentPage.toString()}
+          onValueChange={(value) => setPage(Number(value))}
+        >
+          <SelectTrigger className="h-8 w-16" aria-label="select-page">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {Array.from({ length: totalPages }).map((_, i) => (
+              <SelectItem key={i} value={(i + 1).toString()}>
+                {i + 1}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      ) : (
+        <Button size="icon" variant="outline">
+          1
+        </Button>
+      )}
+
+      <Button
+        variant="outline"
+        className="size-8"
+        size="icon"
+        onClick={() => next(totalPages)}
+        disabled={canGetNextPage}
+      >
+        <span className="sr-only">Go to next page</span>
+        <ChevronRight />
+      </Button>
+      <Button
+        variant="outline"
+        className="size-8 lg:flex"
+        size="icon"
+        onClick={() => last(totalPages)}
+        disabled={canGetNextPage}
+      >
+        <span className="sr-only">Go to last page</span>
+        <ChevronsRight />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,200 +1,257 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import { Check, ChevronRight, Circle } from "lucide-react"
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const DropdownMenu = DropdownMenuPrimitive.Root
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
 
-const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  );
+}
 
-const DropdownMenuGroup = DropdownMenuPrimitive.Group
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  );
+}
 
-const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "max-h-(--radix-dropdown-menu-content-available-height) origin-(--radix-dropdown-menu-content-transform-origin) z-50 min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
 
-const DropdownMenuSub = DropdownMenuPrimitive.Sub
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  );
+}
 
-const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
-
-const DropdownMenuSubTrigger = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
-    inset?: boolean
-  }
->(({ className, inset, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubTrigger
-    ref={ref}
-    className={cn(
-      "flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-      inset && "pl-8",
-      className
-    )}
-    {...props}
-  >
-    {children}
-    <ChevronRight className="ml-auto" />
-  </DropdownMenuPrimitive.SubTrigger>
-))
-DropdownMenuSubTrigger.displayName =
-  DropdownMenuPrimitive.SubTrigger.displayName
-
-const DropdownMenuSubContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className
-    )}
-    {...props}
-  />
-))
-DropdownMenuSubContent.displayName =
-  DropdownMenuPrimitive.SubContent.displayName
-
-const DropdownMenuContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <DropdownMenuPrimitive.Portal>
-    <DropdownMenuPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        className
+        "data-[variant=destructive]:*:[svg]:!text-destructive outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[disabled]:opacity-50 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
       )}
       {...props}
     />
-  </DropdownMenuPrimitive.Portal>
-))
-DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+  );
+}
 
-const DropdownMenuItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-    inset?: boolean
-  }
->(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Item
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-      inset && "pl-8",
-      className
-    )}
-    {...props}
-  />
-))
-DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
-
-const DropdownMenuCheckboxItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
-  <DropdownMenuPrimitive.CheckboxItem
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
-    )}
-    checked={checked}
-    {...props}
-  >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <DropdownMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
-      </DropdownMenuPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </DropdownMenuPrimitive.CheckboxItem>
-))
-DropdownMenuCheckboxItem.displayName =
-  DropdownMenuPrimitive.CheckboxItem.displayName
-
-const DropdownMenuRadioItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
->(({ className, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.RadioItem
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
-    )}
-    {...props}
-  >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <DropdownMenuPrimitive.ItemIndicator>
-        <Circle className="h-2 w-2 fill-current" />
-      </DropdownMenuPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </DropdownMenuPrimitive.RadioItem>
-))
-DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
-
-const DropdownMenuLabel = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
-    inset?: boolean
-  }
->(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Label
-    ref={ref}
-    className={cn(
-      "px-2 py-1.5 text-sm font-semibold",
-      inset && "pl-8",
-      className
-    )}
-    {...props}
-  />
-))
-DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
-
-const DropdownMenuSeparator = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.Separator
-    ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
-    {...props}
-  />
-))
-DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
-
-const DropdownMenuShortcut = ({
+function DropdownMenuCheckboxItem({
   className,
+  children,
+  checked,
   ...props
-}: React.HTMLAttributes<HTMLSpanElement>) => {
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
   return (
-    <span
-      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
       {...props}
     />
-  )
+  );
 }
-DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "outline-hidden relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "outline-hidden flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[inset]:pl-8 data-[state=open]:text-accent-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "origin-(--radix-dropdown-menu-content-transform-origin) z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
 export {
   DropdownMenu,
+  DropdownMenuPortal,
   DropdownMenuTrigger,
   DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
   DropdownMenuItem,
   DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
-  DropdownMenuGroup,
-  DropdownMenuPortal,
   DropdownMenuSub,
-  DropdownMenuSubContent,
   DropdownMenuSubTrigger,
-  DropdownMenuRadioGroup,
-}
+  DropdownMenuSubContent,
+};

--- a/src/features/workspaces/api/query-key-factory.ts
+++ b/src/features/workspaces/api/query-key-factory.ts
@@ -15,5 +15,6 @@ export const workspacesKeys = {
   list: (filters: string) => [...workspacesKeys.lists(), { filters }] as const,
   details: () => [...workspacesKeys.all, "detail"] as const,
   detail: (id: string) => [...workspacesKeys.details(), id] as const,
-  invites: (id: string) => [...workspacesKeys.detail(id), "invites"] as const,
+  invites: ({ id, page = 0 }: { id: string; page: number }) =>
+    [...workspacesKeys.detail(id), "invites", page] as const,
 };

--- a/src/features/workspaces/api/use-accept-workspace-invites/index.ts
+++ b/src/features/workspaces/api/use-accept-workspace-invites/index.ts
@@ -1,0 +1,2 @@
+export * from "./use-accept-workspace-invites";
+export { handlers } from "./mocks";

--- a/src/features/workspaces/api/use-accept-workspace-invites/mocks/handlers/index.ts
+++ b/src/features/workspaces/api/use-accept-workspace-invites/mocks/handlers/index.ts
@@ -1,0 +1,16 @@
+import { http, HttpResponse } from "msw";
+
+const API_ENDPOINT = `${process.env.NEXT_PUBLIC_APP_URL}/api/workspaces/:id/invites`;
+
+export const success = http.post<{ id: string }, { userIds: string[] }>(
+  API_ENDPOINT,
+  async ({ request }) => {
+    const { userIds } = await request.json();
+
+    const res = {
+      members: userIds.map((id) => ({ id })),
+    };
+
+    return HttpResponse.json(res, { status: 200 });
+  },
+);

--- a/src/features/workspaces/api/use-accept-workspace-invites/mocks/index.ts
+++ b/src/features/workspaces/api/use-accept-workspace-invites/mocks/index.ts
@@ -1,0 +1,1 @@
+export * as handlers from "./handlers";

--- a/src/features/workspaces/api/use-accept-workspace-invites/use-accept-workspace-invites.ts
+++ b/src/features/workspaces/api/use-accept-workspace-invites/use-accept-workspace-invites.ts
@@ -1,0 +1,111 @@
+import type { InferRequestType, InferResponseType } from "hono";
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationOptions,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { workspaceInvitesQuery } from "../use-workspace-invites";
+import { hcInit } from "@/lib/hc";
+import type { WorkspacesRouter } from "@/server/routes/workspaces";
+
+const { rpc } = hcInit<WorkspacesRouter>();
+
+export type UseAcceptWorkspaceInvitesRpc =
+  (typeof rpc.api.workspaces)[":id"]["invites"]["$post"];
+
+type RequestType = InferRequestType<UseAcceptWorkspaceInvitesRpc> & {
+  page: number;
+};
+type ResponseType = InferResponseType<UseAcceptWorkspaceInvitesRpc, 200>;
+
+type UseAcceptWorkspaceInvitesOptions = UseMutationOptions<
+  ResponseType,
+  Error,
+  RequestType
+>;
+
+type UseAcceptWorkspaceInvitesResult = UseMutationResult<
+  ResponseType,
+  Error,
+  RequestType
+>;
+
+export function useAcceptWorkspaceInvites(
+  options: UseAcceptWorkspaceInvitesOptions = {},
+): UseAcceptWorkspaceInvitesResult {
+  const queryClient = useQueryClient();
+
+  return useMutation<ResponseType, Error, RequestType>({
+    ...options,
+    mutationFn: async ({ param, json }) => {
+      const res = await rpc.api.workspaces[":id"].invites.$post({
+        json,
+        param,
+      });
+
+      if (!res.ok) {
+        const status = res.status;
+
+        if (status === 401) throw new Error("Unauthorized");
+
+        if (status === 404) throw new Error("Not found");
+
+        if (status === 500)
+          throw new Error(
+            "Something went wrong! We could not add new workspace members successfully, please try again later",
+          );
+      }
+
+      return await res.json();
+    },
+    onMutate: ({ param: { id }, page, json }) => {
+      const userIds = new Set(json.userIds);
+      const cache = queryClient.getQueryData(
+        workspaceInvitesQuery({ page, id }).queryKey,
+      );
+      const updatedInvites = cache?.invites.map((inv) =>
+        !userIds.has(inv.id)
+          ? inv
+          : { ...inv, acceptedAt: new Date(inv.createdAt).toDateString() },
+      );
+
+      const newCache =
+        typeof cache !== "undefined" && typeof updatedInvites !== "undefined"
+          ? {
+              totalPages: cache.totalPages,
+              currentPage: cache.currentPage,
+              invites: updatedInvites,
+            }
+          : undefined;
+
+      queryClient.setQueryData(
+        workspaceInvitesQuery({ page, id }).queryKey,
+        newCache,
+      );
+    },
+    onError: (error, { param: { id }, page }) => {
+      queryClient.invalidateQueries({
+        queryKey: workspaceInvitesQuery({ page, id }).queryKey,
+      });
+
+      toast.error(
+        "Something went wrong when trying to accept user request to join workspace",
+      );
+    },
+    onSuccess: ({ members }, { param: { id }, page }) => {
+      const errors = members?.filter((member) => "error" in member);
+
+      if (errors.length > 0) {
+        queryClient.invalidateQueries({
+          queryKey: workspaceInvitesQuery({ page, id }).queryKey,
+        });
+        toast.error(
+          "Something went wrong when trying to accept some of the user requests to join workspace",
+        );
+      }
+    },
+  });
+}

--- a/src/features/workspaces/api/use-create-workspace/mocks/data/index.ts
+++ b/src/features/workspaces/api/use-create-workspace/mocks/data/index.ts
@@ -7,6 +7,7 @@ export const MOCK_WORKSPACE = {
   id: "c792c258-879a-425b-9399-87fcc0f14b65",
   name: "Test Workspace",
   role: WorkspaceRoles.owner,
+  allowMemberInviteManagement: true,
 };
 
 export const success: InferResponseType<

--- a/src/features/workspaces/api/use-create-workspace/use-create-workspace.test.ts
+++ b/src/features/workspaces/api/use-create-workspace/use-create-workspace.test.ts
@@ -76,7 +76,14 @@ describe("useCreateWorkspace hook test", () => {
       expect(
         qcResult.current.getQueryData(workspacesKeys.lists()),
       ).toStrictEqual({
-        workspaces: [...workspacesQueryData.workspaces, data.success],
+        workspaces: [
+          ...workspacesQueryData.workspaces,
+          {
+            name: data.success.name,
+            id: data.success.id,
+            role: data.success.role,
+          },
+        ],
       });
       expect(
         qcResult.current.getQueryData(

--- a/src/features/workspaces/api/use-create-workspace/use-create-workspace.ts
+++ b/src/features/workspaces/api/use-create-workspace/use-create-workspace.ts
@@ -3,11 +3,10 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
-import { workspacesKeys } from "../query-key-factory";
 import { hcInit } from "@/lib/hc";
 import type { WorkspacesRouter } from "@/server/routes/workspaces";
-import type { UseWorkspacesData } from "../use-workspaces";
-import type { UseWorkspaceData } from "../use-workspace";
+import { workspacesQuery } from "../use-workspaces";
+import { workspaceQuery } from "../use-workspace";
 
 const { rpc } = hcInit<WorkspacesRouter>();
 
@@ -39,20 +38,18 @@ export function useCreateWorkspace() {
     },
     onSuccess: ({ id, name, role }) => {
       toast.success("Workspace created.");
-      queryClient.setQueryData<UseWorkspacesData>(
-        workspacesKeys.lists(),
-        (prev) => {
-          if (prev) {
-            return { workspaces: [...prev.workspaces, { id, name, role }] };
-          } else {
-            return { workspaces: [{ id, name, role }] };
-          }
-        },
-      );
-      queryClient.setQueryData<UseWorkspaceData>(
-        workspacesKeys.detail(id),
-        () => ({ id, name, role }),
-      );
+      queryClient.setQueryData(workspacesQuery.queryKey, (prev) => {
+        if (prev) {
+          return { workspaces: [...prev.workspaces, { id, name, role }] };
+        } else {
+          return { workspaces: [{ id, name, role }] };
+        }
+      });
+      queryClient.setQueryData(workspaceQuery(id).queryKey, () => ({
+        id,
+        name,
+        role,
+      }));
 
       router.push(`/dashboard/workspaces/${id}`);
     },

--- a/src/features/workspaces/api/use-delete-workspace/use-delete-workspace.test.ts
+++ b/src/features/workspaces/api/use-delete-workspace/use-delete-workspace.test.ts
@@ -3,11 +3,12 @@ import { useQueryClient } from "@tanstack/react-query";
 import { server } from "@/tests/mocks/server";
 import { QueryWrapper, createTestQueryClient } from "@/tests/utils";
 
-import { workspacesKeys } from "../query-key-factory";
 import { queryMockWorkspaces } from "../use-workspaces/mocks/utils";
 import { queryMockWorkspace } from "../use-workspace/mocks";
 import { useDeleteWorkspace } from "./use-delete-workspace";
 import { handlers } from "./mocks";
+import { workspacesQuery } from "../use-workspaces";
+import { workspaceQuery } from "../use-workspace";
 
 const push = vi.fn();
 
@@ -49,7 +50,7 @@ describe("useDeleteWorkspace hook test", () => {
       expect(setQueryDataSpy).toHaveBeenCalledTimes(1);
 
       expect(
-        qcResult.current.getQueryData(workspacesKeys.lists()),
+        qcResult.current.getQueryData(workspacesQuery.queryKey),
       ).toStrictEqual({
         workspaces: workspaces.slice(1),
       });
@@ -93,11 +94,11 @@ describe("useDeleteWorkspace hook test", () => {
       // // Query cache should be updated when a workspace is deleted.
       expect(setQueryDataSpy).toHaveBeenCalledTimes(1);
       expect(removeQueriesSpy).toHaveBeenCalledWith({
-        queryKey: workspacesKeys.detail(toDeleteId),
+        queryKey: workspaceQuery(toDeleteId).queryKey,
       });
 
       expect(
-        qcResult.current.getQueryData(workspacesKeys.detail(toDeleteId)),
+        qcResult.current.getQueryData(workspaceQuery(toDeleteId).queryKey),
       ).toBe(undefined);
 
       expect(push).toHaveBeenCalledTimes(2);

--- a/src/features/workspaces/api/use-delete-workspace/use-delete-workspace.ts
+++ b/src/features/workspaces/api/use-delete-workspace/use-delete-workspace.ts
@@ -1,12 +1,17 @@
 import type { InferRequestType, InferResponseType } from "hono";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationOptions,
+  type UseMutationResult,
+} from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
-import { workspacesKeys } from "../query-key-factory";
 import { hcInit } from "@/lib/hc";
 import type { WorkspacesRouter } from "@/server/routes/workspaces";
 import { workspacesQuery } from "../use-workspaces";
+import { workspaceQuery } from "../use-workspace";
 
 const { rpc } = hcInit<WorkspacesRouter>();
 
@@ -15,11 +20,26 @@ export type DeleteWorkspaceRpc = (typeof rpc.api.workspaces)[":id"]["$delete"];
 type RequestType = InferRequestType<DeleteWorkspaceRpc>;
 type ResponseType = InferResponseType<DeleteWorkspaceRpc, 200>;
 
-export function useDeleteWorkspace() {
+type UseDeleteWorkspaceOptions = UseMutationOptions<
+  ResponseType,
+  Error,
+  RequestType
+>;
+
+type UseDeleteWorkspaceResult = UseMutationResult<
+  ResponseType,
+  Error,
+  RequestType
+>;
+
+export function useDeleteWorkspace(
+  options: UseDeleteWorkspaceOptions = {},
+): UseDeleteWorkspaceResult {
   const queryClient = useQueryClient();
   const router = useRouter();
 
   return useMutation<ResponseType, Error, RequestType>({
+    ...options,
     mutationFn: async ({ param }) => {
       const res = await rpc.api.workspaces[":id"].$delete({ param });
 
@@ -31,7 +51,9 @@ export function useDeleteWorkspace() {
 
       return data;
     },
-    onSuccess: ({ id }) => {
+    onSuccess: (data, ...props) => {
+      const { id } = data;
+
       toast.success("Workspace deleted.");
 
       queryClient.setQueryData(workspacesQuery.queryKey, (prev) => {
@@ -43,12 +65,17 @@ export function useDeleteWorkspace() {
           };
       });
 
-      queryClient.removeQueries({ queryKey: workspacesKeys.detail(id) });
+      queryClient.removeQueries({ queryKey: workspaceQuery(id).queryKey });
 
       router.push("/dashboard");
+
+      if (typeof options?.onSuccess === "function")
+        options.onSuccess(data, ...props);
     },
-    onError: () => {
+    onError: (...props) => {
       toast.error("Failed to delete workspace.");
+
+      if (typeof options?.onError === "function") options.onError(...props);
     },
   });
 }

--- a/src/features/workspaces/api/use-delete-workspace/use-delete-workspace.ts
+++ b/src/features/workspaces/api/use-delete-workspace/use-delete-workspace.ts
@@ -6,7 +6,7 @@ import { toast } from "sonner";
 import { workspacesKeys } from "../query-key-factory";
 import { hcInit } from "@/lib/hc";
 import type { WorkspacesRouter } from "@/server/routes/workspaces";
-import type { UseWorkspacesData } from "../use-workspaces";
+import { workspacesQuery } from "../use-workspaces";
 
 const { rpc } = hcInit<WorkspacesRouter>();
 
@@ -34,17 +34,14 @@ export function useDeleteWorkspace() {
     onSuccess: ({ id }) => {
       toast.success("Workspace deleted.");
 
-      queryClient.setQueryData<UseWorkspacesData>(
-        workspacesKeys.lists(),
-        (prev) => {
-          if (typeof prev !== "undefined")
-            return {
-              workspaces: prev.workspaces.filter(
-                (workspace) => workspace.id !== id,
-              ),
-            };
-        },
-      );
+      queryClient.setQueryData(workspacesQuery.queryKey, (prev) => {
+        if (typeof prev !== "undefined")
+          return {
+            workspaces: prev.workspaces.filter(
+              (workspace) => workspace.id !== id,
+            ),
+          };
+      });
 
       queryClient.removeQueries({ queryKey: workspacesKeys.detail(id) });
 

--- a/src/features/workspaces/api/use-soft-delete-workspace-invites/index.ts
+++ b/src/features/workspaces/api/use-soft-delete-workspace-invites/index.ts
@@ -1,0 +1,2 @@
+export * from "./use-soft-delete-workspace-invites";
+export { handlers } from "./mocks";

--- a/src/features/workspaces/api/use-soft-delete-workspace-invites/mocks/handlers/index.ts
+++ b/src/features/workspaces/api/use-soft-delete-workspace-invites/mocks/handlers/index.ts
@@ -1,0 +1,16 @@
+import { http, HttpResponse } from "msw";
+
+const API_ENDPOINT = `${process.env.NEXT_PUBLIC_APP_URL}/api/workspaces/:id/invites`;
+
+export const success = http.patch<{ id: string }, { userIds: string[] }>(
+  API_ENDPOINT,
+  async ({ request }) => {
+    const { userIds } = await request.json();
+
+    const res = {
+      deletedInvites: userIds.map((id) => ({ id })),
+    };
+
+    return HttpResponse.json(res, { status: 200 });
+  },
+);

--- a/src/features/workspaces/api/use-soft-delete-workspace-invites/mocks/index.ts
+++ b/src/features/workspaces/api/use-soft-delete-workspace-invites/mocks/index.ts
@@ -1,0 +1,1 @@
+export * as handlers from "./handlers";

--- a/src/features/workspaces/api/use-soft-delete-workspace-invites/use-soft-delete-workspace-invites.ts
+++ b/src/features/workspaces/api/use-soft-delete-workspace-invites/use-soft-delete-workspace-invites.ts
@@ -1,0 +1,109 @@
+import type { InferRequestType, InferResponseType } from "hono";
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationOptions,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { workspaceInvitesQuery } from "../use-workspace-invites";
+import { hcInit } from "@/lib/hc";
+import type { WorkspacesRouter } from "@/server/routes/workspaces";
+
+const { rpc } = hcInit<WorkspacesRouter>();
+
+export type UseSoftDeleteWorkspaceInvitesRpc =
+  (typeof rpc.api.workspaces)[":id"]["invites"]["$patch"];
+
+type RequestType = InferRequestType<UseSoftDeleteWorkspaceInvitesRpc> & {
+  page: number;
+};
+type ResponseType = InferResponseType<UseSoftDeleteWorkspaceInvitesRpc, 200>;
+
+type UseSoftDeleteWorkspaceInvitesOptions = UseMutationOptions<
+  ResponseType,
+  Error,
+  RequestType
+>;
+
+type UseSoftDeleteWorkspaceInvitesResult = UseMutationResult<
+  ResponseType,
+  Error,
+  RequestType
+>;
+
+export function useSoftDeleteWorkspaceInvites(
+  options: UseSoftDeleteWorkspaceInvitesOptions = {},
+): UseSoftDeleteWorkspaceInvitesResult {
+  const queryClient = useQueryClient();
+
+  return useMutation<ResponseType, Error, RequestType>({
+    ...options,
+    mutationFn: async ({ param, json }) => {
+      const res = await rpc.api.workspaces[":id"].invites.$patch({
+        json,
+        param,
+      });
+
+      if (!res.ok) {
+        const status = res.status;
+
+        if (status === 401) throw new Error("Unauthorized");
+
+        if (status === 404) throw new Error("Not found");
+
+        if (status === 500)
+          throw new Error(
+            "Something went wrong! We could not delete workspace invites successfully, please try again later",
+          );
+      }
+
+      return await res.json();
+    },
+    onMutate: ({ param: { id }, page, json }) => {
+      const userIds = new Set(json.userIds);
+      const cache = queryClient.getQueryData(
+        workspaceInvitesQuery({ page, id }).queryKey,
+      );
+      const deletedInvites = cache?.invites.map((inv) =>
+        !userIds.has(inv.id)
+          ? inv
+          : { ...inv, deletedAt: new Date(inv.createdAt).toDateString() },
+      );
+
+      const newCache =
+        typeof cache !== "undefined" && typeof deletedInvites !== "undefined"
+          ? {
+              totalPages: cache.totalPages,
+              currentPage: cache.currentPage,
+              invites: deletedInvites,
+            }
+          : undefined;
+
+      queryClient.setQueryData(
+        workspaceInvitesQuery({ page, id }).queryKey,
+        newCache,
+      );
+    },
+    onError: (error, { param: { id }, page }) => {
+      queryClient.invalidateQueries({
+        queryKey: workspaceInvitesQuery({ page, id }).queryKey,
+      });
+
+      toast.error("Something went wrong deleting workspace invites.");
+    },
+    onSuccess: ({ deletedInvites }, { param: { id }, page }) => {
+      const errors = deletedInvites?.filter((invite) => "error" in invite);
+
+      if (errors.length > 0) {
+        queryClient.invalidateQueries({
+          queryKey: workspaceInvitesQuery({ page, id }).queryKey,
+        });
+        toast.error(
+          "Something went wrong when trying to delete some of the workspace invites.",
+        );
+      }
+    },
+  });
+}

--- a/src/features/workspaces/api/use-update-invite-code/use-update-invite-code.ts
+++ b/src/features/workspaces/api/use-update-invite-code/use-update-invite-code.ts
@@ -1,5 +1,10 @@
 import type { InferRequestType, InferResponseType } from "hono";
-import { useQueryClient, useMutation } from "@tanstack/react-query";
+import {
+  useQueryClient,
+  useMutation,
+  type UseMutationOptions,
+  type UseMutationResult,
+} from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import { hcInit } from "@/lib/hc";
@@ -14,10 +19,25 @@ export type UpdateInviteCodeRpc =
 type RequestType = InferRequestType<UpdateInviteCodeRpc>;
 type ResponseType = InferResponseType<UpdateInviteCodeRpc, 200>;
 
-export function useUpdateInviteCode() {
+type UseUpdateInviteCodeWorkspaceOptions = UseMutationOptions<
+  ResponseType,
+  Error,
+  RequestType
+>;
+
+type UseUpdateInviteCodeWorkspaceResult = UseMutationResult<
+  ResponseType,
+  Error,
+  RequestType
+>;
+
+export function useUpdateInviteCode(
+  options: UseUpdateInviteCodeWorkspaceOptions = {},
+): UseUpdateInviteCodeWorkspaceResult {
   const queryClient = useQueryClient();
 
   return useMutation<ResponseType, Error, RequestType>({
+    ...options,
     mutationFn: async ({ param, json }) => {
       const res = await rpc.api.workspaces[":id"]["invite-code"].$patch({
         param,
@@ -29,7 +49,8 @@ export function useUpdateInviteCode() {
 
       return data;
     },
-    onSuccess: ({ id, inviteCode }) => {
+    onSuccess: (data, ...props) => {
+      const { id, inviteCode } = data;
       if (inviteCode) {
         toast.success("Invite code updated.");
       } else {
@@ -39,9 +60,14 @@ export function useUpdateInviteCode() {
       queryClient.setQueryData(workspaceQuery(id).queryKey, (prev) => {
         if (prev) return { ...prev, inviteCode };
       });
+
+      if (typeof options?.onSuccess === "function")
+        options.onSuccess(data, ...props);
     },
-    onError: () => {
+    onError: (...props) => {
       toast.error("Failed to update invite code of workspace.");
+
+      if (typeof options?.onError === "function") options.onError(...props);
     },
   });
 }

--- a/src/features/workspaces/api/use-update-invite-code/use-update-invite-code.ts
+++ b/src/features/workspaces/api/use-update-invite-code/use-update-invite-code.ts
@@ -2,10 +2,9 @@ import type { InferRequestType, InferResponseType } from "hono";
 import { useQueryClient, useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-import { workspacesKeys } from "../query-key-factory";
 import { hcInit } from "@/lib/hc";
 import type { WorkspacesRouter } from "@/server/routes/workspaces";
-import type { UseWorkspaceData } from "../use-workspace";
+import { workspaceQuery } from "../use-workspace";
 
 const { rpc } = hcInit<WorkspacesRouter>();
 
@@ -37,12 +36,9 @@ export function useUpdateInviteCode() {
         toast.success("Invite code removed.");
       }
 
-      queryClient.setQueryData<UseWorkspaceData>(
-        workspacesKeys.detail(id),
-        (prev) => {
-          if (prev) return { ...prev, inviteCode };
-        },
-      );
+      queryClient.setQueryData(workspaceQuery(id).queryKey, (prev) => {
+        if (prev) return { ...prev, inviteCode };
+      });
     },
     onError: () => {
       toast.error("Failed to update invite code of workspace.");

--- a/src/features/workspaces/api/use-update-workspace/mocks/data/index.ts
+++ b/src/features/workspaces/api/use-update-workspace/mocks/data/index.ts
@@ -5,12 +5,16 @@ import * as http from "@/server/lib/http-status-codes";
 type SuccessProps = {
   id: string;
   name: string;
+  allowMemberInviteManagement?: boolean;
 };
 
 export function success(
   args: SuccessProps,
 ): InferResponseType<UpdateWorkspaceRpc, typeof http.OK> {
-  return args;
+  return {
+    ...args,
+    allowMemberInviteManagement: args?.allowMemberInviteManagement ?? true,
+  };
 }
 export const successStatus = { status: http.OK };
 

--- a/src/features/workspaces/api/use-update-workspace/use-update-workspace.test.ts
+++ b/src/features/workspaces/api/use-update-workspace/use-update-workspace.test.ts
@@ -3,7 +3,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import { server } from "@/tests/mocks/server";
 import { QueryWrapper, createTestQueryClient } from "@/tests/utils";
 
-import { workspacesKeys } from "../query-key-factory";
+import { workspacesQuery } from "../use-workspaces";
+import { workspaceQuery } from "../use-workspace";
 import { queryMockWorkspaces } from "../use-workspaces/mocks/utils";
 import { queryMockWorkspace } from "../use-workspace/mocks";
 import { useUpdateWorkspace } from "./use-update-workspace";
@@ -67,7 +68,7 @@ describe("useUpdateWorkspace hook test", () => {
       // Query cache should be updated when a workspace is deleted.
       expect(setQueryDataSpy).toHaveBeenCalledTimes(2);
 
-      expect(qcResult.current.getQueryData(workspacesKeys.lists())).toEqual({
+      expect(qcResult.current.getQueryData(workspacesQuery.queryKey)).toEqual({
         workspaces: workspaces.map((workspace) =>
           toUpdateId !== workspace.id ? workspace : { ...workspace, name },
         ),
@@ -94,7 +95,7 @@ describe("useUpdateWorkspace hook test", () => {
       expect(setQueryDataSpy).toHaveBeenCalledTimes(4);
 
       expect(
-        qcResult.current.getQueryData(workspacesKeys.detail(workspace.id)),
+        qcResult.current.getQueryData(workspaceQuery(workspace.id).queryKey),
       ).toEqual({ ...workspace, name });
     });
   });

--- a/src/features/workspaces/api/use-update-workspace/use-update-workspace.ts
+++ b/src/features/workspaces/api/use-update-workspace/use-update-workspace.ts
@@ -2,11 +2,10 @@ import type { InferRequestType, InferResponseType } from "hono";
 import { useQueryClient, useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-import { workspacesKeys } from "../query-key-factory";
 import { hcInit } from "@/lib/hc";
 import type { WorkspacesRouter } from "@/server/routes/workspaces";
-import type { UseWorkspacesData } from "../use-workspaces";
-import type { UseWorkspaceData } from "../use-workspace";
+import { workspacesQuery } from "../use-workspaces";
+import { workspaceQuery } from "../use-workspace";
 
 const { rpc } = hcInit<WorkspacesRouter>();
 
@@ -32,24 +31,18 @@ export function useUpdateWorkspace() {
     onSuccess: ({ id, name }) => {
       toast.success(`Workspace ${name} updated.`);
 
-      queryClient.setQueryData<UseWorkspacesData>(
-        workspacesKeys.lists(),
-        (prev) => {
-          if (prev)
-            return {
-              workspaces: prev.workspaces.map((workspace) =>
-                workspace.id !== id ? workspace : { ...workspace, name },
-              ),
-            };
-        },
-      );
+      queryClient.setQueryData(workspacesQuery.queryKey, (prev) => {
+        if (prev)
+          return {
+            workspaces: prev.workspaces.map((workspace) =>
+              workspace.id !== id ? workspace : { ...workspace, name },
+            ),
+          };
+      });
 
-      queryClient.setQueryData<UseWorkspaceData>(
-        workspacesKeys.detail(id),
-        (prev) => {
-          if (prev) return { ...prev, name };
-        },
-      );
+      queryClient.setQueryData(workspaceQuery(id).queryKey, (prev) => {
+        if (prev) return { ...prev, name };
+      });
     },
     onError: () => {
       toast.error("Failed to update workspace.");

--- a/src/features/workspaces/api/use-workspace-invites/mocks/data/index.ts
+++ b/src/features/workspaces/api/use-workspace-invites/mocks/data/index.ts
@@ -1,78 +1,54 @@
+import { getMockIteratedDate } from "@/tests/utils";
 import type { UseWorkspaceInvitesData } from "../../use-workspace-invites";
 import * as http from "@/server/lib/http-status-codes";
 
-export const success: UseWorkspaceInvitesData = {
-  invites: [
-    {
-      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
-      name: "Test user 1",
-      createdAt: "Wed Jun 11 2025",
-      githubId: null,
-      email: "test@user1.com",
-    },
-    {
-      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
-      name: "Test user 2",
-      createdAt: "Wed Jun 11 2025",
-      githubId: null,
-      email: "test@user2.com",
-    },
-    {
-      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
-      name: "Test user 3",
-      createdAt: "Wed Jun 11 2025",
-      githubId: null,
-      email: "test@user3.com",
-    },
-    {
-      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
-      name: "Test user 4",
-      createdAt: "Wed Jun 11 2025",
-      githubId: null,
-      email: "test@user4.com",
-    },
-    {
-      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
-      name: "Test user 5",
-      createdAt: "Wed Jun 11 2025",
-      githubId: null,
-      email: "test@user5.com",
-    },
-    {
-      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
-      name: "Test user 6",
-      createdAt: "Wed Jun 11 2025",
-      githubId: null,
-      email: "test@user6.com",
-    },
-    {
-      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
-      name: "Test user 7",
-      createdAt: "Wed Jun 11 2025",
-      githubId: null,
-      email: "test@user7.com",
-    },
-    {
-      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
-      name: "Test user 8",
-      createdAt: "Wed Jun 11 2025",
-      githubId: null,
-      email: "test@user8.com",
-    },
-    {
-      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
-      name: "Test user 9",
-      createdAt: "Wed Jun 11 2025",
-      githubId: null,
-      email: "test@user9.com",
-    },
-    {
-      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
-      name: "Test user 10",
-      createdAt: "Wed Jun 11 2025",
-      githubId: null,
-      email: "test@user10.com",
-    },
-  ],
+const TOTAL_INVITES = 20 * 5 - 5;
+const RESULTS_PER_PAGE = 20;
+const TOTAL_PAGES = Math.ceil(TOTAL_INVITES / RESULTS_PER_PAGE);
+
+const BASE_TIMESTAMP_STRING = "2025-02-11 14:14:28.038697";
+
+const blueprint = {
+  name: "Test User",
+  email: "test@user",
+};
+
+const INVITES: UseWorkspaceInvitesData["invites"] = Array.from({
+  length: TOTAL_INVITES,
+}).map((_, i) => ({
+  id: `${i}`,
+  name: blueprint.name + " " + (i + 1),
+  email: `${blueprint.email + i + 1}.com`,
+  createdAt: getMockIteratedDate({
+    index: i,
+    timestamp: BASE_TIMESTAMP_STRING,
+    type: i < 5 ? "increment" : "decrement",
+  }),
+  deletedAt: null,
+  acceptedAt: null,
+  githubId: null,
+}));
+
+export const success = (page: number): UseWorkspaceInvitesData => {
+  const currentPage = TOTAL_PAGES < page ? TOTAL_PAGES : page;
+  const offset =
+    (TOTAL_PAGES < page ? TOTAL_PAGES - 1 : page - 1) * RESULTS_PER_PAGE;
+
+  const invites: UseWorkspaceInvitesData["invites"] = INVITES.slice(
+    offset,
+    offset + RESULTS_PER_PAGE,
+  );
+
+  return {
+    invites,
+    totalPages: TOTAL_PAGES,
+    currentPage,
+  };
 };
 export const successStatus = { status: http.OK };
+
+export const noResults = (page: number): UseWorkspaceInvitesData => ({
+  invites: [],
+  totalPages: 0,
+  currentPage: page,
+});

--- a/src/features/workspaces/api/use-workspace-invites/mocks/data/index.ts
+++ b/src/features/workspaces/api/use-workspace-invites/mocks/data/index.ts
@@ -1,0 +1,78 @@
+import type { UseWorkspaceInvitesData } from "../../use-workspace-invites";
+import * as http from "@/server/lib/http-status-codes";
+
+export const success: UseWorkspaceInvitesData = {
+  invites: [
+    {
+      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
+      name: "Test user 1",
+      createdAt: "Wed Jun 11 2025",
+      githubId: null,
+      email: "test@user1.com",
+    },
+    {
+      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
+      name: "Test user 2",
+      createdAt: "Wed Jun 11 2025",
+      githubId: null,
+      email: "test@user2.com",
+    },
+    {
+      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
+      name: "Test user 3",
+      createdAt: "Wed Jun 11 2025",
+      githubId: null,
+      email: "test@user3.com",
+    },
+    {
+      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
+      name: "Test user 4",
+      createdAt: "Wed Jun 11 2025",
+      githubId: null,
+      email: "test@user4.com",
+    },
+    {
+      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
+      name: "Test user 5",
+      createdAt: "Wed Jun 11 2025",
+      githubId: null,
+      email: "test@user5.com",
+    },
+    {
+      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
+      name: "Test user 6",
+      createdAt: "Wed Jun 11 2025",
+      githubId: null,
+      email: "test@user6.com",
+    },
+    {
+      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
+      name: "Test user 7",
+      createdAt: "Wed Jun 11 2025",
+      githubId: null,
+      email: "test@user7.com",
+    },
+    {
+      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
+      name: "Test user 8",
+      createdAt: "Wed Jun 11 2025",
+      githubId: null,
+      email: "test@user8.com",
+    },
+    {
+      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
+      name: "Test user 9",
+      createdAt: "Wed Jun 11 2025",
+      githubId: null,
+      email: "test@user9.com",
+    },
+    {
+      id: "9ee3ba03-7e14-4cc1-a440-9a6477a303f4",
+      name: "Test user 10",
+      createdAt: "Wed Jun 11 2025",
+      githubId: null,
+      email: "test@user10.com",
+    },
+  ],
+};
+export const successStatus = { status: http.OK };

--- a/src/features/workspaces/api/use-workspace-invites/mocks/handlers/index.ts
+++ b/src/features/workspaces/api/use-workspace-invites/mocks/handlers/index.ts
@@ -1,0 +1,13 @@
+import { http, HttpResponse, delay } from "msw";
+import { data } from "..";
+
+const API_ENDPOINT = `${process.env.NEXT_PUBLIC_APP_URL}/api/workspaces`;
+
+export const success = http.get(API_ENDPOINT, () => {
+  return HttpResponse.json(data.success, data.successStatus);
+});
+
+export const loading = http.get(API_ENDPOINT, async () => {
+  await delay("infinite");
+  return HttpResponse.json(data.success, data.successStatus);
+});

--- a/src/features/workspaces/api/use-workspace-invites/mocks/handlers/index.ts
+++ b/src/features/workspaces/api/use-workspace-invites/mocks/handlers/index.ts
@@ -1,13 +1,36 @@
 import { http, HttpResponse, delay } from "msw";
 import { data } from "..";
 
-const API_ENDPOINT = `${process.env.NEXT_PUBLIC_APP_URL}/api/workspaces`;
+const API_ENDPOINT = `${process.env.NEXT_PUBLIC_APP_URL}/api/workspaces/:id/invites`;
 
-export const success = http.get(API_ENDPOINT, () => {
-  return HttpResponse.json(data.success, data.successStatus);
+export const success = http.get<{ id: string }>(
+  API_ENDPOINT,
+  async ({ request }) => {
+    await delay(1000);
+    const url = new URL(request.url);
+    const pageParam = url.searchParams.get("page");
+
+    const page = isNaN(Number(pageParam)) ? 1 : Number(pageParam);
+
+    return HttpResponse.json(data.success(page), data.successStatus);
+  },
+);
+
+export const loading = http.get(API_ENDPOINT, async ({ request }) => {
+  const url = new URL(request.url);
+  const pageParam = url.searchParams.get("page");
+
+  const page = isNaN(Number(pageParam)) ? 1 : Number(pageParam);
+
+  await delay("infinite");
+  return HttpResponse.json(data.success(page), data.successStatus);
 });
 
-export const loading = http.get(API_ENDPOINT, async () => {
-  await delay("infinite");
-  return HttpResponse.json(data.success, data.successStatus);
+export const noResults = http.get(API_ENDPOINT, async ({ request }) => {
+  const url = new URL(request.url);
+  const pageParam = url.searchParams.get("page");
+
+  const page = isNaN(Number(pageParam)) ? 1 : Number(pageParam);
+
+  return HttpResponse.json(data.noResults(page), data.successStatus);
 });

--- a/src/features/workspaces/api/use-workspace-invites/mocks/index.ts
+++ b/src/features/workspaces/api/use-workspace-invites/mocks/index.ts
@@ -1,0 +1,1 @@
+export * as data from "./data";

--- a/src/features/workspaces/api/use-workspace-invites/mocks/index.ts
+++ b/src/features/workspaces/api/use-workspace-invites/mocks/index.ts
@@ -1,1 +1,2 @@
 export * as data from "./data";
+export * as handlers from "./handlers";

--- a/src/features/workspaces/api/use-workspace-invites/use-workspace-invites.ts
+++ b/src/features/workspaces/api/use-workspace-invites/use-workspace-invites.ts
@@ -1,6 +1,7 @@
 import {
   useInfiniteQuery,
-  // type UseInfiniteQueryResult,
+  type InfiniteData,
+  type UseInfiniteQueryResult,
 } from "@tanstack/react-query";
 import { workspacesKeys } from "../query-key-factory";
 
@@ -10,20 +11,18 @@ import type { WorkspacesRouter } from "@/server/routes/workspaces";
 
 const { rpc } = hcInit<WorkspacesRouter>();
 
-export type WorkspaceRpc =
+export type WorkspaceInvitesRpc =
   (typeof rpc.api.workspaces)[":id"]["invites"]["$get"];
-export type UseWorkspaceData = InferResponseType<WorkspaceRpc, 200>;
+export type UseWorkspaceInvitesData = InferResponseType<
+  WorkspaceInvitesRpc,
+  200
+>;
 
 enum Errors {
   NOT_FOUND = "Not found",
   UNAUTHORIZED = "Unauthorized",
   INTERNAL_SERVER_ERROR = "Internal Server Error",
 }
-
-// type UseWorkspaceInvitesResult = UseInfiniteQueryResult<
-//   UseWorkspaceData,
-//   Error & { cause: Errors }
-// >;
 
 const fetchInvites = async ({
   pageParam,
@@ -59,7 +58,12 @@ const fetchInvites = async ({
   return await res.json();
 };
 
-export function useWorkspaceInvites(workspaceId: string) {
+export function useWorkspaceInvites(
+  workspaceId: string,
+): UseInfiniteQueryResult<
+  InfiniteData<UseWorkspaceInvitesData, unknown>,
+  Error
+> {
   return useInfiniteQuery({
     queryKey: workspacesKeys.invites(workspaceId),
     initialPageParam: 1,

--- a/src/features/workspaces/api/use-workspace/mocks/data/index.ts
+++ b/src/features/workspaces/api/use-workspace/mocks/data/index.ts
@@ -16,6 +16,7 @@ export const successOwner: WorkspaceResponseOk = {
   name: MOCK_WORKSPACE_NAME,
   role: WorkspaceRoles.owner,
   inviteCode: MOCK_WORKSPACE_INVITE_CODE,
+  allowMemberInviteManagement: true,
 };
 
 export const successAdmin: WorkspaceResponseOk = {
@@ -23,6 +24,7 @@ export const successAdmin: WorkspaceResponseOk = {
   name: MOCK_WORKSPACE_NAME,
   role: WorkspaceRoles.admin,
   inviteCode: MOCK_WORKSPACE_INVITE_CODE,
+  allowMemberInviteManagement: true,
 };
 
 export const successUser: WorkspaceResponseOk = {
@@ -30,24 +32,28 @@ export const successUser: WorkspaceResponseOk = {
   name: MOCK_WORKSPACE_NAME,
   role: WorkspaceRoles.user,
   inviteCode: MOCK_WORKSPACE_INVITE_CODE,
+  allowMemberInviteManagement: true,
 };
 
 export const successOwnerNoInvite: WorkspaceResponseOk = {
   id: MOCK_WORKSPACE_ID,
   name: MOCK_WORKSPACE_NAME,
   role: WorkspaceRoles.admin,
+  allowMemberInviteManagement: true,
 };
 
 export const successAdminNoInvite: WorkspaceResponseOk = {
   id: MOCK_WORKSPACE_ID,
   name: MOCK_WORKSPACE_NAME,
   role: WorkspaceRoles.admin,
+  allowMemberInviteManagement: true,
 };
 
 export const successUserNoInvite: WorkspaceResponseOk = {
   id: MOCK_WORKSPACE_ID,
   name: MOCK_WORKSPACE_NAME,
   role: WorkspaceRoles.user,
+  allowMemberInviteManagement: true,
 };
 
 export const successStatus = { status: http.OK };
@@ -71,6 +77,7 @@ type CreateMockWorkspaceDataProps =
       id?: string;
       name?: string;
       role?: WorkspaceRoles;
+      allowMemberInviteManagement?: boolean;
     }
   | undefined;
 
@@ -78,8 +85,9 @@ export function createMockWorkspaceData(
   props: CreateMockWorkspaceDataProps,
 ): WorkspaceResponseOk {
   return {
-    id: props?.id || MOCK_WORKSPACE_ID,
-    name: props?.name || "Example Workspace",
-    role: props?.role || WorkspaceRoles.owner,
+    id: props?.id ?? MOCK_WORKSPACE_ID,
+    name: props?.name ?? "Example Workspace",
+    role: props?.role ?? WorkspaceRoles.owner,
+    allowMemberInviteManagement: props?.allowMemberInviteManagement ?? true,
   };
 }

--- a/src/features/workspaces/api/use-workspaces/use-workspaces.ts
+++ b/src/features/workspaces/api/use-workspaces/use-workspaces.ts
@@ -1,5 +1,9 @@
 import type { InferResponseType } from "hono";
-import { useQuery } from "@tanstack/react-query";
+import {
+  useQuery,
+  queryOptions,
+  type UseQueryOptions,
+} from "@tanstack/react-query";
 import { toast } from "sonner";
 import { workspacesKeys } from "../query-key-factory";
 import { hcInit } from "@/lib/hc";
@@ -10,29 +14,35 @@ const { rpc } = hcInit<WorkspacesRouter>();
 export type WorkspacesRpc = (typeof rpc.api.workspaces)["$get"];
 export type UseWorkspacesData = InferResponseType<WorkspacesRpc, 200>;
 
-export function useWorkspaces() {
-  return useQuery({
-    queryKey: workspacesKeys.lists(),
-    queryFn: async () => {
-      const res = await rpc.api.workspaces.$get();
+type UseWorkspacesQueryOptions = UseQueryOptions<UseWorkspacesData, Error>;
 
-      if (!res.ok) {
-        const data = await res.json();
+export const workspacesQuery = queryOptions<UseWorkspacesData, Error>({
+  queryKey: workspacesKeys.lists(),
+  queryFn: async () => {
+    const res = await rpc.api.workspaces.$get();
 
-        let errMessage: string;
+    if (!res.ok) {
+      const data = await res.json();
 
-        if (typeof data?.error === "string") {
-          errMessage = data.error;
-        } else {
-          errMessage = "Something went wrong. Could not load workspaces.";
-        }
+      let errMessage: string;
 
-        toast.error(errMessage);
-
-        throw new Error(errMessage);
+      if (typeof data?.error === "string") {
+        errMessage = data.error;
+      } else {
+        errMessage = "Something went wrong. Could not load workspaces.";
       }
 
-      return await res.json();
-    },
-  });
+      toast.error(errMessage);
+
+      throw new Error(errMessage);
+    }
+
+    return await res.json();
+  },
+});
+
+export function useWorkspaces(options?: UseWorkspacesQueryOptions) {
+  return useQuery(
+    options ? { ...options, ...workspacesQuery } : workspacesQuery,
+  );
 }

--- a/src/features/workspaces/components/delete-workspace-card/delete-workspace-card.tsx
+++ b/src/features/workspaces/components/delete-workspace-card/delete-workspace-card.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useEffect } from "react";
+import { useCallback, useState } from "react";
 
 import { useDeleteWorkspace } from "@/features/workspaces/api/use-delete-workspace";
 import {
@@ -47,17 +47,15 @@ function DeleteWorkspaceModal({
   description,
 }: DeleteWorkspaceModalProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const { mutate, isPending, isError } = useDeleteWorkspace();
+  const { mutate, isPending } = useDeleteWorkspace({
+    onError: () => setIsOpen(false),
+  });
 
   const closeModal = useCallback(() => setIsOpen(false), []);
 
   const deleteWorkspace = useCallback(() => {
     mutate({ param: { id: workspaceId } });
   }, [mutate, workspaceId]);
-
-  useEffect(() => {
-    if (isError) setIsOpen(false);
-  }, [isError]);
 
   return (
     <>

--- a/src/features/workspaces/components/invites-table/index.ts
+++ b/src/features/workspaces/components/invites-table/index.ts
@@ -1,0 +1,1 @@
+export * from "./invites-table";

--- a/src/features/workspaces/components/invites-table/invite-table-actions.tsx
+++ b/src/features/workspaces/components/invites-table/invite-table-actions.tsx
@@ -1,0 +1,70 @@
+import { Button } from "@/components/ui/button";
+import { Check, X } from "lucide-react";
+import { useAcceptWorkspaceInvites } from "../../api/use-accept-workspace-invites";
+import { useSoftDeleteWorkspaceInvites } from "../../api/use-soft-delete-workspace-invites";
+
+type InviteTableActionsProps = {
+  page: number;
+  userId: string;
+  workspaceId: string;
+  deletedAt: string | null;
+  acceptedAt: string | null;
+};
+
+export function InviteTableActions({
+  page,
+  userId,
+  workspaceId,
+  deletedAt,
+  acceptedAt,
+}: InviteTableActionsProps) {
+  const { mutate: acceptInvite } = useAcceptWorkspaceInvites();
+  const { mutate: deleteInvite } = useSoftDeleteWorkspaceInvites();
+
+  if (deletedAt)
+    return (
+      <div className="flex h-8 w-full items-center justify-end text-destructive">
+        <span className="block">Deleted</span>
+      </div>
+    );
+
+  if (acceptedAt)
+    return (
+      <div className="flex h-8 w-full items-center justify-end text-success">
+        <span className="block">Accepted</span>
+      </div>
+    );
+
+  return (
+    <div className="flex w-full justify-end gap-3">
+      <Button
+        size={"icon"}
+        onClick={() =>
+          acceptInvite({
+            page,
+            param: { id: workspaceId },
+            json: { userIds: [userId] },
+          })
+        }
+      >
+        <Check />
+        <span className="sr-only">Accept join request</span>
+      </Button>
+
+      <Button
+        size={"icon"}
+        variant="destructive"
+        onClick={() =>
+          deleteInvite({
+            page,
+            param: { id: workspaceId },
+            json: { userIds: [userId] },
+          })
+        }
+      >
+        <X />
+        <span className="sr-only">Reject and delete join request</span>
+      </Button>
+    </div>
+  );
+}

--- a/src/features/workspaces/components/invites-table/invites-table.stories.tsx
+++ b/src/features/workspaces/components/invites-table/invites-table.stories.tsx
@@ -1,0 +1,71 @@
+import type { StoryObj, Meta } from "@storybook/react";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+
+import { QueryWrapper, withMswHandlers } from "@/tests/utils";
+import { handlers as GET } from "../../api/use-workspace-invites/mocks";
+import { handlers as POST } from "../../api/use-accept-workspace-invites/mocks";
+import { handlers as PATCH } from "../../api/use-soft-delete-workspace-invites/mocks";
+import { InvitesTable } from "./invites-table";
+import { MOCK_WORKSPACE_ID } from "../../api/use-workspace/mocks/data";
+import { WorkspaceRoles } from "@/server/db/schemas";
+
+const meta = {
+  title: "Features/Workspace/Invites Table",
+  component: InvitesTable,
+  decorators: (Story) => (
+    <NuqsTestingAdapter>
+      <QueryWrapper>
+        <div className="max-w-xxl min-h-screen w-[70vw] py-8">
+          <Story />
+        </div>
+      </QueryWrapper>
+    </NuqsTestingAdapter>
+  ),
+  args: {
+    workspaceId: MOCK_WORKSPACE_ID,
+  },
+} satisfies Meta<typeof InvitesTable>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  ...withMswHandlers([GET.success, POST.success, PATCH.success]),
+  args: {
+    allowMemberInviteManagement: true,
+    role: WorkspaceRoles.owner,
+  },
+};
+
+export const Loading: Story = {
+  ...withMswHandlers([GET.loading, POST.success, PATCH.success]),
+  args: {
+    allowMemberInviteManagement: true,
+    role: WorkspaceRoles.owner,
+  },
+};
+
+export const NoResults: Story = {
+  ...withMswHandlers([GET.noResults, POST.success, PATCH.success]),
+  args: {
+    allowMemberInviteManagement: true,
+    role: WorkspaceRoles.owner,
+  },
+};
+
+export const RestrictedInviteManagementUser: Story = {
+  ...withMswHandlers([GET.success, POST.success, PATCH.success]),
+  args: {
+    allowMemberInviteManagement: false,
+    role: WorkspaceRoles.user,
+  },
+};
+
+export const RestrictedInviteManagementAdmin: Story = {
+  ...withMswHandlers([GET.success, POST.success, PATCH.success]),
+  args: {
+    allowMemberInviteManagement: false,
+    role: WorkspaceRoles.admin,
+  },
+};

--- a/src/features/workspaces/components/invites-table/invites-table.tsx
+++ b/src/features/workspaces/components/invites-table/invites-table.tsx
@@ -1,0 +1,170 @@
+"use client";
+import { useMemo } from "react";
+import {
+  type ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  useWorkspaceInvites,
+  type UseWorkspaceInvitesData,
+} from "@/features/workspaces/api/use-workspace-invites";
+import { usePaginationSearchParams } from "@/hooks/use-pagination-search-params";
+import { Loader } from "@/components/shared/loader";
+import { Pagination } from "@/components/shared/pagination";
+import { cn } from "@/lib/utils";
+import { WorkspaceRoles } from "@/server/db/schemas";
+import { InviteTableActions } from "./invite-table-actions";
+
+export type InvitesTableProps = {
+  workspaceId: string;
+  allowMemberInviteManagement: boolean;
+  role: WorkspaceRoles;
+};
+
+export function InvitesTable({
+  workspaceId,
+  allowMemberInviteManagement,
+  role,
+}: InvitesTableProps) {
+  const { page, ...props } = usePaginationSearchParams();
+
+  const columns = useMemo<
+    ColumnDef<UseWorkspaceInvitesData["invites"][0]>[]
+  >(() => {
+    const actions: ColumnDef<UseWorkspaceInvitesData["invites"][0]>[] =
+      allowMemberInviteManagement || role !== WorkspaceRoles.user
+        ? [
+            {
+              id: "actions",
+              header: () => (
+                <div className="ml-auto w-3">
+                  <span className="sr-only">Actions</span>
+                </div>
+              ),
+              cell: ({ row }) => (
+                <InviteTableActions
+                  page={page}
+                  workspaceId={workspaceId}
+                  userId={row.original.id}
+                  deletedAt={row.original.deletedAt}
+                  acceptedAt={row.original.acceptedAt}
+                />
+              ),
+            },
+          ]
+        : [];
+
+    return [
+      {
+        accessorKey: "name",
+        header: "Name",
+      },
+      {
+        accessorKey: "createdAt",
+        header: "Requested On",
+      },
+      ...actions,
+    ];
+  }, [allowMemberInviteManagement, page, role, workspaceId]);
+
+  const { data, isLoading, isFetching } = useWorkspaceInvites({
+    id: workspaceId,
+    page,
+    options: { staleTime: 1000 * 60 },
+  });
+
+  const table = useReactTable({
+    data: data?.invites ?? [],
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    keepPinnedRows: true,
+    manualPagination: true,
+    state: {
+      pagination: {
+        pageIndex: data ? data.currentPage - 1 : page - 1,
+        pageSize: data ? data.invites.length : 0,
+      },
+    },
+    pageCount: data ? data.totalPages : -1,
+  });
+
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                return (
+                  <TableHead key={header.id} className={cn(header)}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </TableHead>
+                );
+              })}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows?.length ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow
+                key={row.id}
+                data-state={row.getIsSelected() && "selected"}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : isLoading ? (
+            <TableRow>
+              <TableCell colSpan={columns.length} className="h-32 text-center">
+                <Loader className="mx-auto size-6" />
+              </TableCell>
+            </TableRow>
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columns.length} className="h-32 text-center">
+                No results.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+
+      <div className="flex h-12 w-full items-center justify-center">
+        {!isLoading && isFetching && <Loader />}
+      </div>
+
+      {data && data.totalPages > 1 && (
+        <Pagination
+          totalPages={data.totalPages}
+          currentPage={data.currentPage}
+          canGetNextPage={!table.getCanNextPage()}
+          canGetPrevPage={!table.getCanPreviousPage()}
+          {...props}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/features/workspaces/components/workspace-switcher/workspace-switcher.stories.tsx
+++ b/src/features/workspaces/components/workspace-switcher/workspace-switcher.stories.tsx
@@ -9,8 +9,7 @@ import {
 } from "@/tests/utils";
 import { WorkspaceSwitcher } from "./workspace-switcher";
 import { handlers, data } from "../../api/use-workspaces/mocks";
-import { workspacesKeys } from "../../api/query-key-factory";
-import type { UseWorkspacesData } from "../../api/use-workspaces";
+import { workspacesQuery } from "../../api/use-workspaces";
 import { Toaster } from "@/components/ui/sonner";
 
 const meta = {
@@ -37,7 +36,7 @@ export const Default: Story = withMswHandlers([handlers.successExtended]);
 export const Loading: Story = withMswHandlers([handlers.loading]);
 
 const queryClient = createTestQueryClient();
-queryClient.setQueryData<UseWorkspacesData>(workspacesKeys.lists(), () => ({
+queryClient.setQueryData(workspacesQuery.queryKey, () => ({
   workspaces: data.MOCK_WORKSPACES,
 }));
 

--- a/src/hooks/use-pagination-search-params.ts
+++ b/src/hooks/use-pagination-search-params.ts
@@ -1,0 +1,73 @@
+import { useQueryState, parseAsInteger, type Options } from "nuqs";
+import { useCallback } from "react";
+
+export const PAGE_SEARCH_PARAM = "page";
+
+export type UsePaginationSearchParamsReturnT = {
+  page: number;
+  setPage: (
+    value: number | ((old: number) => number | null) | null,
+    options?: Options,
+  ) => Promise<URLSearchParams>;
+  next: (totalPages?: number) => void;
+  prev: (totalPages?: number) => void;
+  last: (totalPages?: number) => void;
+  first: () => void;
+};
+
+export function usePaginationSearchParams(
+  pageSearchParam: string = PAGE_SEARCH_PARAM,
+): UsePaginationSearchParamsReturnT {
+  const [page, setPage] = useQueryState(
+    pageSearchParam,
+    parseAsInteger.withDefault(1),
+  );
+
+  const next = useCallback(
+    (totalPages?: number) => {
+      if (typeof totalPages === "number") {
+        setPage((prev) => (totalPages > prev ? prev + 1 : prev));
+      } else {
+        setPage((prev) => prev + 1);
+      }
+    },
+    [setPage],
+  );
+
+  const prev = useCallback(
+    (totalPages?: number) => {
+      if (typeof totalPages === "number") {
+        setPage((prev) => {
+          if (totalPages < prev - 1) return totalPages - 1;
+
+          return prev > 1 ? prev - 1 : prev;
+        });
+      } else {
+        setPage((prev) => prev - 1);
+      }
+    },
+    [setPage],
+  );
+
+  const first = useCallback(() => {
+    setPage(1);
+  }, [setPage]);
+
+  const last = useCallback(
+    (totalPages?: number) => {
+      if (typeof totalPages === "number") {
+        setPage(totalPages);
+      }
+    },
+    [setPage],
+  );
+
+  return {
+    page,
+    setPage,
+    next,
+    prev,
+    last,
+    first,
+  };
+}

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,3 +1,4 @@
+import { contextStorage } from "hono/context-storage";
 import { createApp } from "@/server/lib/create-app";
 import { configureOpenAPI } from "@/server/lib/configure-open-api";
 import { authRouter } from "@/server/routes/auth";
@@ -5,6 +6,8 @@ import { workspacesRouter } from "@/server/routes/workspaces";
 
 const app = createApp();
 configureOpenAPI(app);
+
+app.use(contextStorage());
 
 const routes = [authRouter, workspacesRouter] as const;
 

--- a/src/server/db/migrations/0002_shocking_ravenous.sql
+++ b/src/server/db/migrations/0002_shocking_ravenous.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "workspaces" ADD COLUMN "allow_member_invite_management" boolean DEFAULT true NOT NULL;

--- a/src/server/db/migrations/0003_opposite_madrox.sql
+++ b/src/server/db/migrations/0003_opposite_madrox.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "workspaces_requests" ADD COLUMN "deleted_at" timestamp;--> statement-breakpoint
+ALTER TABLE "workspaces_requests" ADD COLUMN "accepted_at" timestamp;

--- a/src/server/db/migrations/meta/0002_snapshot.json
+++ b/src/server/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,349 @@
+{
+  "id": "5007f652-c4bf-4717-9930-9e148039c4be",
+  "prevId": "fcdedb30-5019-44eb-a689-85d17e1e4642",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "char(6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_member_invite_management": {
+          "name": "allow_member_invite_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces_members": {
+      "name": "workspaces_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_members_user_id_users_id_fk": {
+          "name": "workspaces_members_user_id_users_id_fk",
+          "tableFrom": "workspaces_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_members_workspace_id_workspaces_id_fk": {
+          "name": "workspaces_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspaces_members",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspaces_members_pk": {
+          "name": "workspaces_members_pk",
+          "columns": [
+            "user_id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces_requests": {
+      "name": "workspaces_requests",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_requests_user_id_users_id_fk": {
+          "name": "workspaces_requests_user_id_users_id_fk",
+          "tableFrom": "workspaces_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_requests_workspace_id_workspaces_id_fk": {
+          "name": "workspaces_requests_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspaces_requests",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspaces_requests_pk": {
+          "name": "workspaces_requests_pk",
+          "columns": [
+            "user_id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "owner"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/server/db/migrations/meta/0003_snapshot.json
+++ b/src/server/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,361 @@
+{
+  "id": "6bd7a6cd-b3a6-44e7-ae7b-13c0e50c0544",
+  "prevId": "5007f652-c4bf-4717-9930-9e148039c4be",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "char(6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_member_invite_management": {
+          "name": "allow_member_invite_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces_members": {
+      "name": "workspaces_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_members_user_id_users_id_fk": {
+          "name": "workspaces_members_user_id_users_id_fk",
+          "tableFrom": "workspaces_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_members_workspace_id_workspaces_id_fk": {
+          "name": "workspaces_members_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspaces_members",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspaces_members_pk": {
+          "name": "workspaces_members_pk",
+          "columns": [
+            "user_id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces_requests": {
+      "name": "workspaces_requests",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_requests_user_id_users_id_fk": {
+          "name": "workspaces_requests_user_id_users_id_fk",
+          "tableFrom": "workspaces_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspaces_requests_workspace_id_workspaces_id_fk": {
+          "name": "workspaces_requests_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspaces_requests",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspaces_requests_pk": {
+          "name": "workspaces_requests_pk",
+          "columns": [
+            "user_id",
+            "workspace_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin",
+        "owner"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/server/db/migrations/meta/_journal.json
+++ b/src/server/db/migrations/meta/_journal.json
@@ -15,6 +15,20 @@
       "when": 1741684978028,
       "tag": "0001_closed_madripoor",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1749882696463,
+      "tag": "0002_shocking_ravenous",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1750442575501,
+      "tag": "0003_opposite_madrox",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/schemas/index.ts
+++ b/src/server/db/schemas/index.ts
@@ -9,6 +9,7 @@ import {
   bigint,
   pgEnum,
   char,
+  boolean,
 } from "drizzle-orm/pg-core";
 
 export const users = pgTable("users", {
@@ -48,6 +49,9 @@ export const workspaces = pgTable("workspaces", {
   id: uuid("id").primaryKey().defaultRandom(),
   name: varchar("name", { length: 255 }).notNull(),
   inviteCode: char("invite_code", { length: 6 }),
+  allowMemberInviteManagement: boolean("allow_member_invite_management")
+    .notNull()
+    .default(true),
 });
 
 export const workspacesRelations = relations(workspaces, ({ many }) => ({
@@ -112,6 +116,8 @@ export const workspacesRequests = pgTable(
       .notNull()
       .references(() => workspaces.id, { onDelete: "cascade" }),
     createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    deletedAt: timestamp("deleted_at", { mode: "date" }),
+    acceptedAt: timestamp("accepted_at", { mode: "date" }),
   },
 
   (table) => [

--- a/src/server/middlewares/is-workspace-member.ts
+++ b/src/server/middlewares/is-workspace-member.ts
@@ -1,0 +1,26 @@
+// import { createMiddleware } from "hono/factory";
+// import type { SessionMiddlewareVariables } from "./session";
+// import { getContext } from "hono/context-storage";
+
+// export type IsWorkspaceMemberMiddlewareVariables =
+//   SessionMiddlewareVariables & {
+//     test: string;
+//   };
+
+// export const isWorkspaceMemberMiddleware = createMiddleware<{
+//   Variables: IsWorkspaceMemberMiddlewareVariables;
+// }>(async (c, next) => {
+//   const user = getContext<{ Variables: SessionMiddlewareVariables }>().var.user;
+//   const workspaceId = c.req.param("id");
+
+//   if (typeof workspaceId !== "string") {
+//     const errMessage =
+//       "isWorkspaceMemberMiddleware is being used for a route that does not have workspace ID parameter.";
+//     console.error(errMessage);
+//     throw new Error(errMessage);
+//   }
+
+//   c.set("test", `${workspaceId}`);
+
+//   await next();
+// });

--- a/src/server/middlewares/session.ts
+++ b/src/server/middlewares/session.ts
@@ -114,5 +114,5 @@ export const sessionMiddleware = createMiddleware<{
     }
   }
 
-  return next();
+  await next();
 });

--- a/src/server/routes/workspaces/handlers/accept-workspace-invites.ts
+++ b/src/server/routes/workspaces/handlers/accept-workspace-invites.ts
@@ -1,0 +1,134 @@
+import { eq, and, inArray, isNull } from "drizzle-orm";
+import { db } from "@/server/db";
+import {
+  workspaces,
+  workspacesMembers,
+  workspacesRequests,
+  users,
+  WorkspaceRoles,
+} from "@/server/db/schemas";
+import * as http from "@/server/lib/http-status-codes";
+
+import type {
+  AppMiddlewareVariables,
+  AppRouteHandler,
+} from "@/server/lib/types";
+import type { SessionMiddlewareVariables } from "@/server/middlewares/session";
+import type { AcceptWorkspaceInvitesRoute } from "../workspaces.routes";
+
+export const acceptWorkspaceInvitesHandler: AppRouteHandler<
+  AcceptWorkspaceInvitesRoute,
+  AppMiddlewareVariables<SessionMiddlewareVariables>
+> = async (c) => {
+  const user = c.get("user");
+  const { id: workspaceId } = c.req.valid("param");
+  const { userIds } = c.req.valid("json");
+
+  try {
+    const [workspaceMembership] = await db
+      .select({
+        role: workspacesMembers.role,
+        allowMemberInviteManagement: workspaces.allowMemberInviteManagement,
+      })
+      .from(workspacesMembers)
+      .innerJoin(workspaces, eq(workspaces.id, workspaceId))
+      .where(eq(workspacesMembers.userId, user.id));
+
+    if (!workspaceMembership)
+      return c.json({ error: "Not found" }, http.NOT_FOUND);
+
+    if (
+      !workspaceMembership.allowMemberInviteManagement &&
+      workspaceMembership.role === WorkspaceRoles.user
+    ) {
+      return c.json({ error: "Unauthorized" }, http.UNAUTHORIZED);
+    }
+
+    const existingUserRecords = await db
+      .select()
+      .from(users)
+      .where(inArray(users.id, userIds));
+
+    const validUserIdsFromPayload = existingUserRecords.map((u) => u.id);
+
+    if (validUserIdsFromPayload.length === 0) {
+      return c.json(
+        {
+          error: "No users with specified IDs have been found.",
+        },
+        http.NOT_FOUND,
+      );
+    }
+
+    const pendingInvites = await db
+      .select({ userId: workspacesRequests.userId })
+      .from(workspacesRequests)
+      .where(
+        and(
+          eq(workspacesRequests.workspaceId, workspaceId),
+          isNull(workspacesRequests.acceptedAt),
+          isNull(workspacesRequests.deletedAt),
+          inArray(workspacesRequests.userId, validUserIdsFromPayload),
+        ),
+      );
+
+    if (pendingInvites.length === 0) {
+      return c.json(
+        {
+          error:
+            "No pending invites for users with specified IDs have been found.",
+        },
+        http.NOT_FOUND,
+      );
+    }
+
+    const userIdsToAccept = pendingInvites.map((invite) => invite.userId);
+    const userIdsToAcceptSet = new Set(userIdsToAccept);
+
+    const membersToInsert = existingUserRecords.filter(({ id }) =>
+      userIdsToAcceptSet.has(id),
+    );
+
+    await Promise.all([
+      db
+        .insert(workspacesMembers)
+        .values(membersToInsert.map((u) => ({ userId: u.id, workspaceId })))
+        .onConflictDoNothing(),
+
+      db
+        .update(workspacesRequests)
+        .set({
+          acceptedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(workspacesRequests.workspaceId, workspaceId),
+            inArray(workspacesRequests.userId, userIdsToAccept),
+          ),
+        ),
+    ]);
+
+    return c.json(
+      {
+        members: userIds.map((id) => {
+          const member = membersToInsert.find((mem) => mem.id === id);
+
+          return member
+            ? { id: member.id, name: member.name }
+            : {
+                id,
+                error:
+                  "Specified user in the request not found in pending workspace requests",
+              };
+        }),
+      },
+      http.OK,
+    );
+  } catch (error) {
+    console.error("Error accepting workspace invites:", error);
+    return c.json(
+      { error: "Internal Server Error" },
+      http.INTERNAL_SERVER_ERROR,
+    );
+  }
+};

--- a/src/server/routes/workspaces/handlers/create-workspace.ts
+++ b/src/server/routes/workspaces/handlers/create-workspace.ts
@@ -37,7 +37,10 @@ export const createWorkspaceHandler: AppRouteHandler<
       role,
     });
 
-    return c.json({ id: workspaceId, name, role }, http.CREATED);
+    return c.json(
+      { id: workspaceId, name, role, allowMemberInviteManagement: true },
+      http.CREATED,
+    );
   } catch (error) {
     console.log(error);
 

--- a/src/server/routes/workspaces/handlers/index.ts
+++ b/src/server/routes/workspaces/handlers/index.ts
@@ -6,3 +6,5 @@ export * from "./delete-workspace";
 export * from "./join-workspace";
 export * from "./update-invite-code";
 export * from "./get-workspace-invites";
+export * from "./accept-workspace-invites";
+export * from "./soft-delete-workspace-invites";

--- a/src/server/routes/workspaces/handlers/soft-delete-workspace-invites.ts
+++ b/src/server/routes/workspaces/handlers/soft-delete-workspace-invites.ts
@@ -1,0 +1,127 @@
+import { eq, and, inArray, isNull } from "drizzle-orm";
+import { db } from "@/server/db";
+import {
+  workspaces,
+  workspacesMembers,
+  workspacesRequests,
+  users,
+  WorkspaceRoles,
+} from "@/server/db/schemas";
+import * as http from "@/server/lib/http-status-codes";
+
+import type {
+  AppMiddlewareVariables,
+  AppRouteHandler,
+} from "@/server/lib/types";
+import type { SessionMiddlewareVariables } from "@/server/middlewares/session";
+import type { SoftDeleteWorkspaceInvitesRoute } from "../workspaces.routes";
+
+export const softDeleteWorkspaceInvitesHandler: AppRouteHandler<
+  SoftDeleteWorkspaceInvitesRoute,
+  AppMiddlewareVariables<SessionMiddlewareVariables>
+> = async (c) => {
+  const user = c.get("user");
+  const { id: workspaceId } = c.req.valid("param");
+  const { userIds } = c.req.valid("json");
+
+  try {
+    const [workspaceMembership] = await db
+      .select({
+        role: workspacesMembers.role,
+        allowMemberInviteManagement: workspaces.allowMemberInviteManagement,
+      })
+      .from(workspacesMembers)
+      .innerJoin(workspaces, eq(workspaces.id, workspaceId))
+      .where(eq(workspacesMembers.userId, user.id));
+
+    if (!workspaceMembership)
+      return c.json({ error: "Not found" }, http.NOT_FOUND);
+
+    if (
+      !workspaceMembership.allowMemberInviteManagement &&
+      workspaceMembership.role === WorkspaceRoles.user
+    ) {
+      return c.json({ error: "Unauthorized" }, http.UNAUTHORIZED);
+    }
+
+    const existingUserRecords = await db
+      .select()
+      .from(users)
+      .where(inArray(users.id, userIds));
+
+    const validUserIdsFromPayload = existingUserRecords.map((u) => u.id);
+
+    if (validUserIdsFromPayload.length === 0) {
+      return c.json(
+        {
+          error:
+            "No user requests with specified IDs have been found for workspace.",
+        },
+        http.NOT_FOUND,
+      );
+    }
+
+    const pendingInvites = await db
+      .select({ userId: workspacesRequests.userId })
+      .from(workspacesRequests)
+      .where(
+        and(
+          eq(workspacesRequests.workspaceId, workspaceId),
+          isNull(workspacesRequests.acceptedAt),
+          isNull(workspacesRequests.deletedAt),
+          inArray(workspacesRequests.userId, validUserIdsFromPayload),
+        ),
+      );
+
+    if (pendingInvites.length === 0) {
+      return c.json(
+        {
+          error:
+            "No pending invites for users with specified IDs have been found.",
+        },
+        http.NOT_FOUND,
+      );
+    }
+
+    const userIdInvitesToSoftDelete = pendingInvites.map(
+      (invite) => invite.userId,
+    );
+
+    await db
+      .update(workspacesRequests)
+      .set({
+        deletedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(workspacesRequests.workspaceId, workspaceId),
+          inArray(workspacesRequests.userId, userIdInvitesToSoftDelete),
+        ),
+      );
+
+    return c.json(
+      {
+        deletedInvites: userIds.map((id) => {
+          const invite = userIdInvitesToSoftDelete.find((inv) => inv === id);
+
+          return invite
+            ? {
+                id: invite,
+              }
+            : {
+                id,
+                error:
+                  "Specified user in the request not found in pending workspace requests",
+              };
+        }),
+      },
+      http.OK,
+    );
+  } catch (error) {
+    console.error("Error deleting workspace invites:", error);
+    return c.json(
+      { error: "Internal Server Error" },
+      http.INTERNAL_SERVER_ERROR,
+    );
+  }
+};

--- a/src/server/routes/workspaces/handlers/update-workspace.ts
+++ b/src/server/routes/workspaces/handlers/update-workspace.ts
@@ -20,7 +20,7 @@ export const updateWorkspaceHandler: AppRouteHandler<
 > = async (c) => {
   const user = c.get("user");
   const { id: workspaceId } = c.req.valid("param");
-  const { name } = c.req.valid("json");
+  const { name, allowMemberInviteManagement } = c.req.valid("json");
 
   try {
     const [workspace] = await db
@@ -28,6 +28,7 @@ export const updateWorkspaceHandler: AppRouteHandler<
         id: workspaces.id,
         name: workspaces.name,
         role: workspacesMembers.role,
+        allowMemberInviteManagement: workspaces.allowMemberInviteManagement,
       })
       .from(workspacesMembers)
       .innerJoin(workspaces, eq(workspaces.id, workspaceId))
@@ -40,10 +41,22 @@ export const updateWorkspaceHandler: AppRouteHandler<
 
     await db
       .update(workspaces)
-      .set({ name })
+      .set({
+        name,
+        allowMemberInviteManagement:
+          allowMemberInviteManagement ?? workspace.allowMemberInviteManagement,
+      })
       .where(eq(workspaces.id, workspace.id));
 
-    return c.json({ id: workspaceId, name }, http.OK);
+    return c.json(
+      {
+        id: workspaceId,
+        name,
+        allowMemberInviteManagement:
+          allowMemberInviteManagement ?? workspace.allowMemberInviteManagement,
+      },
+      http.OK,
+    );
   } catch (error) {
     console.log(error);
 

--- a/src/server/routes/workspaces/index.ts
+++ b/src/server/routes/workspaces/index.ts
@@ -9,6 +9,8 @@ import {
   joinWorkspaceHandler,
   updateInviteCodeHandler,
   getWorkspaceInvitesHandler,
+  acceptWorkspaceInvitesHandler,
+  softDeleteWorkspaceInvitesHandler,
 } from "./handlers";
 import {
   getWorkspaceRoute,
@@ -19,6 +21,8 @@ import {
   joinWorkspaceRoute,
   updateInviteCodeRoute,
   getWorkspaceInvitesRoute,
+  acceptWorkspaceInvitesRoute,
+  softDeleteWorkspaceInvitesRoute,
 } from "./workspaces.routes";
 
 export const workspacesRouter = createRouter()
@@ -29,6 +33,8 @@ export const workspacesRouter = createRouter()
   .openapi(deleteWorkspaceRoute, deleteWorkspaceHandler)
   .openapi(joinWorkspaceRoute, joinWorkspaceHandler)
   .openapi(updateInviteCodeRoute, updateInviteCodeHandler)
-  .openapi(getWorkspaceInvitesRoute, getWorkspaceInvitesHandler);
+  .openapi(getWorkspaceInvitesRoute, getWorkspaceInvitesHandler)
+  .openapi(acceptWorkspaceInvitesRoute, acceptWorkspaceInvitesHandler)
+  .openapi(softDeleteWorkspaceInvitesRoute, softDeleteWorkspaceInvitesHandler);
 
 export type WorkspacesRouter = typeof workspacesRouter;

--- a/src/server/routes/workspaces/workspaces.routes.ts
+++ b/src/server/routes/workspaces/workspaces.routes.ts
@@ -57,6 +57,7 @@ export const getWorkspaceRoute = createRoute({
         name: z.string(),
         role: z.nativeEnum(WorkspaceRoles),
         inviteCode: z.string().length(6).optional(),
+        allowMemberInviteManagement: z.boolean(),
       }),
       "Workspaces",
     ),
@@ -88,11 +89,11 @@ export const createWorkspaceRoute = createRoute({
   },
   responses: {
     [http.CREATED]: jsonContent(
-      // TODO: extract after migrating from AppWrite
       z.object({
         id: z.string(),
         name: z.string(),
         role: z.nativeEnum(WorkspaceRoles),
+        allowMemberInviteManagement: z.boolean(),
       }),
       "Create Workspace",
     ),
@@ -115,6 +116,7 @@ export type CreateWorkspaceRoute = typeof createWorkspaceRoute;
 // TODO: extract after migrating from AppWrite
 const updateWorkspaceSchema = z.object({
   name: z.string({ message: "Workspace name is required." }).trim().min(1),
+  allowMemberInviteManagement: z.boolean().optional(),
 });
 
 export const updateWorkspaceRoute = createRoute({
@@ -128,7 +130,11 @@ export const updateWorkspaceRoute = createRoute({
   },
   responses: {
     [http.OK]: jsonContent(
-      z.object({ id: z.string(), name: z.string() }),
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        allowMemberInviteManagement: z.boolean(),
+      }),
       "Update Workspace",
     ),
     [http.UNAUTHORIZED]: jsonContent(
@@ -241,7 +247,7 @@ export const getWorkspaceInvitesRoute = createRoute({
   request: {
     params: workspaceParamsSchema,
     query: z.object({
-      page: z.number({ coerce: true }),
+      page: z.number({ coerce: true }).min(1),
     }),
   },
   responses: {
@@ -252,10 +258,14 @@ export const getWorkspaceInvitesRoute = createRoute({
             id: z.string(),
             name: z.string(),
             createdAt: z.date(),
+            deletedAt: z.union([z.date(), z.null()]),
+            acceptedAt: z.union([z.date(), z.null()]),
             githubId: z.union([z.number(), z.null()]),
             email: z.union([z.string(), z.null()]),
           }),
         ),
+        totalPages: z.number(),
+        currentPage: z.number(),
       }),
       "Workspace Invites",
     ),
@@ -271,3 +281,88 @@ export const getWorkspaceInvitesRoute = createRoute({
   },
 });
 export type GetWorkspaceInvitesRoute = typeof getWorkspaceInvitesRoute;
+
+export const acceptWorkspaceInvitesRoute = createRoute({
+  method: "post",
+  path: "/api/workspaces/{id}/invites",
+  tags,
+  middleware: [sessionMiddleware] as const,
+  request: {
+    params: workspaceParamsSchema,
+    body: jsonContentRequired(
+      z.object({
+        userIds: z.array(z.string().uuid()),
+      }),
+      "Accept workspace invites schema",
+    ),
+  },
+  responses: {
+    [http.OK]: jsonContent(
+      z.object({
+        members: z.array(
+          z.union([
+            z.object({
+              id: z.string(),
+              error: z.string(),
+            }),
+            z.object({
+              id: z.string(),
+              name: z.string(),
+            }),
+          ]),
+        ),
+      }),
+      "New Workspace Members",
+    ),
+    [http.UNAUTHORIZED]: jsonContent(
+      createErrorMessageSchema(),
+      "Unauthorized",
+    ),
+    [http.NOT_FOUND]: jsonContent(createErrorMessageSchema(), "Not found"),
+    [http.INTERNAL_SERVER_ERROR]: jsonContent(
+      createErrorMessageSchema(),
+      "Internal Server Error",
+    ),
+  },
+});
+export type AcceptWorkspaceInvitesRoute = typeof acceptWorkspaceInvitesRoute;
+
+export const softDeleteWorkspaceInvitesRoute = createRoute({
+  method: "patch",
+  path: "/api/workspaces/{id}/invites",
+  tags,
+  middleware: [sessionMiddleware] as const,
+  request: {
+    params: workspaceParamsSchema,
+    body: jsonContentRequired(
+      z.object({
+        userIds: z.array(z.string().uuid()),
+      }),
+      "Accept workspace invites schema",
+    ),
+  },
+  responses: {
+    [http.OK]: jsonContent(
+      z.object({
+        deletedInvites: z.array(
+          z.object({
+            id: z.string(),
+            error: z.string().optional(),
+          }),
+        ),
+      }),
+      "Deleted Invites",
+    ),
+    [http.UNAUTHORIZED]: jsonContent(
+      createErrorMessageSchema(),
+      "Unauthorized",
+    ),
+    [http.NOT_FOUND]: jsonContent(createErrorMessageSchema(), "Not found"),
+    [http.INTERNAL_SERVER_ERROR]: jsonContent(
+      createErrorMessageSchema(),
+      "Internal Server Error",
+    ),
+  },
+});
+export type SoftDeleteWorkspaceInvitesRoute =
+  typeof softDeleteWorkspaceInvitesRoute;

--- a/src/tests/utils.tsx
+++ b/src/tests/utils.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render } from "@testing-library/react";
 import { delay, type HttpHandler } from "msw";
@@ -35,7 +36,7 @@ export function QueryWrapper({
   children,
   queryClient,
 }: React.PropsWithChildren & { queryClient?: QueryClient }) {
-  const testQueryClient = createTestQueryClient();
+  const [testQueryClient] = useState(() => createTestQueryClient());
   return (
     <QueryClientProvider client={queryClient || testQueryClient}>
       {children}
@@ -65,4 +66,87 @@ export function withMswHandlers(handlers: HttpHandler[]) {
       },
     },
   };
+}
+
+export type GetMockIteratedDateProps = {
+  /**
+   * The numerical index used to calculate the date offset.
+   * This typically comes from an array map function's index.
+   */
+  index: number;
+  /**
+   * The base timestamp string in the same format that `drizzle` timestamp is, `'YYYY-MM-DD HH:MM:SS.ms'`,
+   * from which the new date will be calculated.
+   */
+  timestamp: string;
+  /**
+   * The type of operation to perform on the date.
+   * - 'increment': Adds `index` days to the base timestamp (default).
+   * - 'decrement': Subtracts `index` days from the base timestamp.
+   * @default "increment"
+   */
+  type?: "increment" | "decrement";
+};
+
+/**
+ * Generates a mock date string by incrementing or decrementing a base timestamp
+ * by a specified number of days.
+ *
+ * This function is useful for creating mock data where dates need to be
+ * sequential (e.g., for paginated results or chronological events).
+ * It handles month and year rollovers automatically.
+ *
+ * @param {GetMockIteratedDateProps} props - The properties for date generation.
+ * @returns {string} The formatted date string in 'YYYY-MM-DD HH:MM:SS.ms000' format.
+ * @throws {Error} If an invalid timestamp string is provided.
+ *
+ * @example
+ * // Incrementing dates
+ * getMockIteratedDate({ index: 0, timestamp: '2024-04-11 14:14:28.038697' });
+ * // Returns: "2024-04-11 14:14:28.038000"
+ *
+ * getMockIteratedDate({ index: 1, timestamp: '2024-04-11 14:14:28.038697' });
+ * // Returns: "2024-04-12 14:14:28.038000"
+ *
+ * getMockIteratedDate({ index: 30, timestamp: '2024-04-11 14:14:28.038697' });
+ * // Returns: "2024-05-11 14:14:28.038000" (handles month rollover)
+ *
+ * @example
+ * // Decrementing dates
+ * getMockIteratedDate({ index: 1, timestamp: '2024-04-11 14:14:28.038697', type: 'decrement' });
+ * // Returns: "2024-04-10 14:14:28.038000"
+ *
+ * getMockIteratedDate({ index: 45, timestamp: '2024-04-11 14:14:28.038697', type: 'decrement' });
+ * // Returns: "2024-02-26 14:14:28.038000" (handles month rollover)
+ */
+export function getMockIteratedDate({
+  index,
+  timestamp,
+  type = "increment",
+}: GetMockIteratedDateProps): string {
+  const baseDate = new Date(timestamp);
+
+  // Check if parsing was successful
+  if (isNaN(baseDate.getTime()))
+    throw new Error(
+      "getMockIteratedDate should be provided with a valid timestamp",
+    );
+
+  const currentDate = new Date(baseDate.getTime());
+  currentDate.setDate(
+    currentDate.getDate() + (type === "increment" ? index : -index),
+  );
+
+  const year = currentDate.getFullYear();
+  const month = (currentDate.getMonth() + 1).toString().padStart(2, "0");
+  const day = currentDate.getDate().toString().padStart(2, "0");
+  const hours = currentDate.getHours().toString().padStart(2, "0");
+  const minutes = currentDate.getMinutes().toString().padStart(2, "0");
+  const seconds = currentDate.getSeconds().toString().padStart(2, "0");
+  const milliseconds = currentDate
+    .getMilliseconds()
+    .toString()
+    .padStart(3, "0");
+
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}.${milliseconds}000`;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,5 +41,11 @@
     "**/*.mts",
     ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "public/*.js", "coverage"]
+  "exclude": [
+    "node_modules",
+    "public/*.js",
+    "coverage",
+    "storybook-static",
+    "test-results"
+  ]
 }


### PR DESCRIPTION
Refactoring query and mutation hooks to use `queryOptions` from TanstackQuery for better type-safety. Updating mocks and tests accordingly.

Adding the BE functionality to query (with pagination), accept and delete workspace join requests. Database schema updated accordingly.

Adding FE queries, mutations and components to display invites, accept and delete them with role-based access.